### PR TITLE
chore: request less permission for dconf access

### DIFF
--- a/flatpak/io.geph.GephGui.yml
+++ b/flatpak/io.geph.GephGui.yml
@@ -57,7 +57,7 @@ finish-args:
   # Needed for OpenGL
   - --device=dri
   # DConf access for configuring proxies
-  - --filesystem=host:rw
+  - --filesystem=xdg-run/dconf
   - --talk-name=ca.desrt.dconf
   - --talk-name=org.freedesktop.Flatpak
   - --env=DCONF_USER_CONFIG_DIR=.config/dconf


### PR DESCRIPTION
According to https://docs.flatpak.org/en/latest/sandbox-permissions.html?highlight=dconf#dconf-access, DConf access doesn't require file system access as board as `--filesystem=host`. More strict permission requests help keep things safe.