### PR TITLE
upgrade sdk to 44

### DIFF
--- a/flatpak/io.geph.GephGui.yml
+++ b/flatpak/io.geph.GephGui.yml
@@ -1,10 +1,10 @@
 app-id: io.geph.GephGui
 runtime: org.gnome.Platform
-runtime-version: "41"
+runtime-version: "44"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-  - org.freedesktop.Sdk.Extension.node14
+  - org.freedesktop.Sdk.Extension.node16
 command: "gephgui-wry"
 modules:
   # - shared-modules/intltool/intltool-0.51.json


### PR DESCRIPTION
```
Info: runtime org.gnome.Platform branch 41 is end-of-life, with reason:
   The GNOME 41 runtime is no longer supported as of September 17, 2022. Please ask your application developer to migrate to a supported platform.
```